### PR TITLE
Use relative inputDir path as a part of the FlatBuffers task cache key

### DIFF
--- a/src/main/groovy/io/netifi/flatbuffers/plugin/tasks/FlatBuffers.groovy
+++ b/src/main/groovy/io/netifi/flatbuffers/plugin/tasks/FlatBuffers.groovy
@@ -30,6 +30,7 @@ import org.gradle.process.internal.ExecException
 class FlatBuffers extends DefaultTask {
 
     @Optional
+    @PathSensitive(PathSensitivity.RELATIVE)
     @InputDirectory
     File inputDir
 


### PR DESCRIPTION
This enables remote cache usage and through that increases the probability of cache hit on `FlatBuffers` task.